### PR TITLE
Make the plugin compatible with TYPO3 8

### DIFF
--- a/Classes/FrontendHook.php
+++ b/Classes/FrontendHook.php
@@ -81,6 +81,28 @@ class FrontendHook
         return $this->main($content, $conf);
     }
 
+    /**
+     * AddSlash array
+     * This function traverses a multidimensional array and adds slashes to the values.
+     * NOTE that the input array is and argument by reference.!!
+     * Twin-function to stripSlashesOnArray
+     *
+     * @param array $theArray Multidimensional input array, (REFERENCE!)
+     * @return array
+     */
+    public static function addSlashesOnArray(array &$theArray)
+    {
+        foreach ($theArray as &$value) {
+            if (is_array($value)) {
+                self::addSlashesOnArray($value);
+            } else {
+                $value = addslashes($value);
+            }
+        }
+        unset($value);
+        reset($theArray);
+    }
+
 
     /**
      * this is the actual main function that replaces the glossary
@@ -124,7 +146,7 @@ class FrontendHook
         if (GeneralUtility::_GP('tx_a21glossary')) {
             $this->piVars = GeneralUtility::_GP('tx_a21glossary');
             if (count($this->piVars)) {
-                GeneralUtility::addSlashesOnArray($this->piVars);
+                self::addSlashesOnArray($this->piVars);
             }
         }
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -127,11 +127,12 @@ plugin.tx_a21glossary {
 		}
 		orderBy = {$a21glossary.orderBy}
 		where = exclude=0
-		andWhere {
+		where.append = TEXT
+		where.append {
 			data = GP:tx_a21glossary|uid
 			intval = 1
 			required = 1
-			wrap = uid=|
+			noTrimWrap = | AND uid=||
 		}
 		languageField = sys_language_uid
 	}


### PR DESCRIPTION
The current master is not fully compatible with TYPO3 8 because especially 2 functions, being used in the plugin, have been removed in TYPO3 8. Those functions are `GeneralUtility::addSlashesOnArray` in PHP and `select.andWhere` in TypoScript.

This patch contains fixes for both. I would be very happy if you could wrap this in a new TER version, since the current TER version is really not TYPO3 8 compatible.