### PR TITLE
Ensure fetchGlossaryItems returns always array

### DIFF
--- a/Classes/FrontendHook.php
+++ b/Classes/FrontendHook.php
@@ -419,7 +419,7 @@ class FrontendHook
      */
     protected function fetchGlossaryItems($pidList): array
     {
-
+        $items = array();
         // -1 means: ignore pids
         if ('' === trim($pidList)) {
             $pidList = '-1';


### PR DESCRIPTION
Avoid Fatal error: Uncaught TypeError: Return value of A21Glossary\A21Glossary\FrontendHook::fetchGlossaryItems() must be of the type array, null returned ... if configuration of pidList is not given.