### PR TITLE
Update composer.json to require typo3/cms-core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://wappler.systems",
     "license": "GPL-2.0-or-later",
     "require": {
-        "typo3/cms": ">=8.7.0, <8.7.99"
+        "typo3/cms-core": ">=8.7.0, <8.7.99"
     },
     "replace": {
         "svewap/a21glossary": "self.version"


### PR DESCRIPTION
For minimal TYPO3 installations this needs to be typo3/cms-core, otherwise you can't require this package.