### PR TITLE
[BUGFIX] Do not declare package to replace itself

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "typo3/cms-core": "^9.5.0 || ^10.4.0"
     },
     "replace": {
-        "svewap/a21glossary": "self.version"
+        "typo3-ter/a21glossary": "self.version"
     }
 }


### PR DESCRIPTION
The former declaration of this package to replace itself makes it
impossible in a project to require "dev-master" as it's going to
be replaced by "dev-dev", which does not work with TYPO3 v8.
(composer v2 behaviour!)

Instead it should only replace the package available at TYPO3 satis.