### PR TITLE
[BUGFIX] Use correct composer replace entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "typo3/cms-core": "^8.7.0 || ^9.5.0"
     },
     "replace": {
-        "a21glossary": "self.version"
+        "typo3-ter/a21glossary": "self.version"
     }
 }


### PR DESCRIPTION
The replace section must contain valid composer names.
This package replaces any package found on TYPO3 satis.