### PR TITLE
Setting to only show abbreviations in the glossary list

### DIFF
--- a/Classes/Controller/GlossaryController.php
+++ b/Classes/Controller/GlossaryController.php
@@ -27,10 +27,14 @@ class GlossaryController extends ActionController
      */
     public function indexAction($char = null): ResponseInterface
     {
+        $showAbbreviationsOnlyInGlossaryList = isset($this->settings['showAbbreviationsOnlyInGlossaryList'])
+             ? (bool)$this->settings['showAbbreviationsOnlyInGlossaryList']
+             : false;
+        
         if (!empty($char)) {
-            $glossaryItems = $this->glossaryRepository->findAllWithChar($char);
+            $glossaryItems = $this->glossaryRepository->findAllWithChar($char, $showAbbreviationsOnlyInGlossaryList);
         } else {
-            $glossaryItems = $this->glossaryRepository->findAll();
+            $glossaryItems = $this->glossaryRepository->findAllFiltered($showAbbreviationsOnlyInGlossaryList);
         }
 
         $paginationConfiguration = $this->settings['paginate'] ?? [];
@@ -48,7 +52,7 @@ class GlossaryController extends ActionController
             $pagination = GeneralUtility::makeInstance(SimplePagination::class, $paginator);
         }
 
-        $this->view->assign('index', $this->glossaryRepository->findAllForIndex());
+        $this->view->assign('index', $this->glossaryRepository->findAllForIndex($showAbbreviationsOnlyInGlossaryList));
         $this->view->assign('currentChar', $char);
         $this->view->assign('pagination', ['pagination' => $pagination, 'paginator' => $paginator]);
 
@@ -62,8 +66,12 @@ class GlossaryController extends ActionController
      */
     public function searchAction($q): ResponseInterface
     {
+        $showAbbreviationsOnlyInGlossaryList = isset($this->settings['showAbbreviationsOnlyInGlossaryList'])
+             ? (bool)$this->settings['showAbbreviationsOnlyInGlossaryList']
+             : false;
+
         $this->view->assign('q', $q);
-        $this->view->assign('items', $this->glossaryRepository->findAllWithQuery($q));
+        $this->view->assign('items', $this->glossaryRepository->findAllWithQuery($q, $showAbbreviationsOnlyInGlossaryList));
 
         return $this->htmlResponse();
     }

--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -22,7 +22,19 @@ class GlossaryRepository extends Repository
         'short' => QueryInterface::ORDER_ASCENDING
     ];
 
-    public function findAllForIndex()
+    public function findAllFiltered(bool $showAbbreviationsOnlyInGlossaryList)
+    {
+        $query = $this->createQuery();
+
+        if ($showAbbreviationsOnlyInGlossaryList) {
+            $constraints = [$query->equals('shorttype', 'abbr')];
+            $query->matching($constraints[0]);
+        }
+
+        return $query->execute();
+    }
+
+    public function findAllForIndex(bool $showAbbreviationsOnlyInGlossaryList)
     {
         /** @var Query $query */
         $query = $this->createQuery();
@@ -34,42 +46,70 @@ class GlossaryRepository extends Repository
             ->groupBy('char')
             ->orderBy('char', 'ASC');
 
+        if ($showAbbreviationsOnlyInGlossaryList) {
+            $queryBuilder->where(
+                $queryBuilder->expr()->eq(
+                    'shorttype',
+                    $queryBuilder->createNamedParameter('abbr')
+                )
+            );
+        }
+
         return $query->statement($queryBuilder)->execute(true);
     }
 
     /**
      * @param string $char
+     * @param bool $showAbbreviationsOnlyInGlossaryList 
      *
      * @return Glossary[]|QueryResultInterface
      * @throws InvalidQueryException
      */
-    public function findAllWithChar(string $char): QueryResultInterface|array
+    public function findAllWithChar(string $char, bool $showAbbreviationsOnlyInGlossaryList): QueryResultInterface|array
     {
         $query = $this->createQuery();
-        $query->matching(
-            $query->like('short', $char . '%')
-        );
+        
+        $constraints = [$query->like('short', $char . '%')];
+
+        if ($showAbbreviationsOnlyInGlossaryList) {
+            $constraints[] = $query->equals('shorttype', 'abbr');
+        }
+
+        if (count($constraints) > 1) {
+            $query->matching($query->logicalAnd(...$constraints));
+        } else {
+            $query->matching($constraints[0]);
+        }
 
         return $query->execute();
     }
 
     /**
      * @param string $q
+     * @param bool $showAbbreviationsOnlyInGlossaryList 
      *
      * @return Glossary[]|QueryResultInterface
      * @throws InvalidQueryException
      */
-    public function findAllWithQuery(string $q): QueryResultInterface|array
+    public function findAllWithQuery(string $q, bool $showAbbreviationsOnlyInGlossaryList): QueryResultInterface|array
     {
         $query = $this->createQuery();
-        $query->matching(
-            $query->logicalOr(
-                $query->like('short', '%' . $q . '%'),
-                $query->like('shortcut', '%' . $q . '%'),
-                $query->like('longversion', '%' . $q . '%'),
-                $query->like('description', '%' . $q . '%')
-            )
-        );
+
+        $orConstraints = [$query->like('short', '%' . $q . '%'), $query->like('shortcut', '%' . $q . '%'), $query->like('longversion', '%' . $q . '%'), $query->like('description', '%' . $q . '%') ];
+
+        if ($showAbbreviationsOnlyInGlossaryList) {
+            $query->matching(
+                $query->logicalAnd(
+                    $query->logicalOr(...$orConstraints),
+                    $query->equals('shorttype', 'abbr')
+                )
+            );
+        }
+        else {
+            $query->matching(
+                $query->logicalOr(...$orConstraints)
+            );
+        }
 
         return $query->execute();
     }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -71,6 +71,9 @@ plugin.tx_a21glossary {
       insertBelow = 1
       maximumNumberOfLinks = 5
     }
+
+    # if set to 1, only abbreviations are shown in the glossary
+    showAbbreviationsOnlyInGlossaryList = 0
   }
 }
 


### PR DESCRIPTION
We would like to add the possibility of including only abbreviations in the glossary list. We have added an option in the setup.typoscript to enable this feature.
The default behavior remains unchanged.